### PR TITLE
Packaging: Add documentation files to sdist package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,9 @@ prune examples
 prune vendor
 prune templates
 prune tests
+
+# Documentation
+recursive-include docs *
+prune docs/_build
+global-exclude */__pycache__/*
+global-exclude *.pyc

--- a/README.rst
+++ b/README.rst
@@ -62,8 +62,8 @@ A picture says a thousand words.
 Notification service coverage
 =============================
 
-*mqttwarn* comes with **over 70 notification handler plugins** for a wide
-range of notification services and is very open to further contributions.
+*mqttwarn* comes with **over 70 notification handler plugins**, covering a
+wide range of notification services and is very open to further contributions.
 You can enjoy the alphabetical list of plugins on the `mqttwarn notifier
 catalog`_ page.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,7 @@ About
    :target: #
 
 *mqttwarn* is a highly configurable MQTT message router, where the routing targets
-are notification plugins, written in Python. A picture says a thousand words.
+are notification plugins, primarily written in Python. A picture says a thousand words.
 
 
 ********


### PR DESCRIPTION
Following up on GH-650, this patch brings back the documentation to the sdist tarball. Because it will include the full documentation now, the tarball size increases from 126k to 964k. The size of the wheel package, which is usually used for installation purposes, is still small (119k). Do you think it is a good idea?