### PR TITLE
A bit of core sanding (80-100)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ in progress
 
 - Add example "Simple MQTT media player". Thanks, @nagyrobi.
 - Add example "Forwarding data from IoT devices to Zabbix"
+- Remove support for Secure Sockets Layer Version 3.0 (SSLv3).
+  As per RFC 7568, SSLv3 has been deprecated in 2015 already.
 
 
 2023-04-28 0.34.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ in progress
 - Add example "Forwarding data from IoT devices to Zabbix"
 - Remove support for Secure Sockets Layer Version 3.0 (SSLv3).
   As per RFC 7568, SSLv3 has been deprecated in 2015 already.
+- Tests: Add more test cases to increase mqttwarn core coverage to ~100%
 
 
 2023-04-28 0.34.0

--- a/mqttwarn/__init__.py
+++ b/mqttwarn/__init__.py
@@ -7,7 +7,7 @@ __license__ = "Eclipse Public License - v 2.0 (http://www.eclipse.org/legal/epl-
 
 try:
     from importlib.metadata import version
-except ImportError:
+except ImportError:  # pragma: nocover
     from importlib_metadata import version  # type: ignore[no-redef]
 
 __version__ = version("mqttwarn")

--- a/mqttwarn/configuration.py
+++ b/mqttwarn/configuration.py
@@ -88,8 +88,6 @@ class Config(RawConfigParser):
                 self.tls_version = ssl.PROTOCOL_TLSv1_1
             if self.tls_version == "tlsv1":
                 self.tls_version = ssl.PROTOCOL_TLSv1
-            if self.tls_version == "sslv3":
-                self.tls_version = ssl.PROTOCOL_SSLv3
 
         self.loglevelnumber = self.level2number(self.loglevel)
         self.filteredmessagesloglevelnumber = self.level2number(self.filteredmessagesloglevel)

--- a/mqttwarn/context.py
+++ b/mqttwarn/context.py
@@ -112,15 +112,11 @@ class RuntimeContext:
 
         2021-10-18 [amo]: Be more graceful with jobs w/o any target address information.
         """
-        targets: t.List[TopicTargetType] = []
-        try:
-            targets = self.config.getdict("config:" + service, "targets")
-        except:
-            logger.exception("Unable to access targets for service `%s'" % service)
+        targets: t.List[TopicTargetType] = self.config.getdict("config:" + service, "targets")
 
         # TODO: The target address descriptor may be of any type these days,
         #       and not necessarily a list.
-        # TODO: Currently, this makes sure to always return one element.
+        # TODO: Currently, make sure to always return one element.
         #       Verify if this is really needed.
         targets = targets or [None]
         return targets

--- a/mqttwarn/model.py
+++ b/mqttwarn/model.py
@@ -59,6 +59,7 @@ class ProcessorItem:
     service: Optional[str] = None
     target: Optional[str] = None
     config: Dict = field(default_factory=dict)
+    section: Optional[str] = None
     # TODO: `addrs` can also be a string or dictionary now.
     addrs: TopicTargetType = field(default_factory=list)  # type: ignore[assignment]
     priority: Optional[int] = None
@@ -72,6 +73,17 @@ class ProcessorItem:
 
     def get(self, key, default=None):
         return getattr(self, key, default)
+
+    def to_job(self) -> "Job":
+        return Job(
+            prio=self.priority,
+            service=self.service,
+            section=self.section,
+            topic=self.topic,
+            payload=self.message,
+            data=self.data,
+            target=self.target,
+        )
 
 
 @dataclasses.dataclass

--- a/mqttwarn/services/noop.py
+++ b/mqttwarn/services/noop.py
@@ -1,0 +1,13 @@
+from mqttwarn.model import Service, ProcessorItem
+
+
+def plugin(srv: Service, item: ProcessorItem) -> bool:
+    """
+    An mqttwarn plugin with little overhead, suitable for unit- and integration-testing.
+    """
+    if hasattr(item, "message") and item.message and "fail" in item.message:
+        srv.logging.error("Failed sending message using noop")
+        return False
+    else:
+        srv.logging.info("Successfully sent message using noop")
+        return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,8 +86,9 @@ files = [
 [tool.pytest.ini_options]
 minversion = "2.0"
 addopts = "-rsfEX -p pytester --strict-markers --verbosity=3 --cov --cov-report=term-missing --cov-report=xml --cov-report html:.pytest_results/htmlcov"
-log_level = "DEBUG"
+# log_cli = true  # Enable to receive way more log details on stdout.
 log_cli_level = "DEBUG"
+log_level = "DEBUG"
 testpaths = ["examples", "mqttwarn", "tests"]
 xfail_strict = true
 markers = [

--- a/tests/etc/full.ini
+++ b/tests/etc/full.ini
@@ -101,6 +101,11 @@ format = {name}: {value}
 targets = log:info
 format = xform_func()
 
+[test/log-unknown-func]
+; Validate invoking an unknown function croaks.
+targets = log:info
+format = unknown_func()
+
 [test/file-1]
 ; echo '{"name": "temperature", "value": 42.42}' | mosquitto_pub -h localhost -t test/file-1 -l
 targets = file:test-1

--- a/tests/services/test_http.py
+++ b/tests/services/test_http.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# (c) 2023 The mqttwarn developers
+from mqttwarn.configuration import Config
+from mqttwarn.core import bootstrap, load_services
+
+
+def test_http_urllib_load_by_alias(caplog):
+    """
+    Verify loading the `http` service works, even if its implementation module is called `http_urllib`.
+    """
+
+    config = Config()
+    config.add_section("config:http")
+    bootstrap(config=config)
+    load_services(["http"])

--- a/tests/services/test_log.py
+++ b/tests/services/test_log.py
@@ -29,7 +29,7 @@ def test_log_invalid_target(caplog):
     assert (
         "mqttwarn.core",
         30,
-        "Notification of log for `test/targets-interpolated' FAILED or TIMED OUT",
+        "Notification failed or timed out. service=log, topic=test/targets-interpolated",
     ) in caplog.record_tuples
 
 
@@ -51,10 +51,10 @@ def test_log_broken_target(caplog):
     assert (
         "mqttwarn.core",
         40,
-        "Invoking service 'log' failed: `item.addrs` is not a list",
+        "Invoking service failed. Reason: `item.addrs` is not a list. service=log, topic=test/targets-interpolated",
     ) in caplog.record_tuples
     assert (
         "mqttwarn.core",
         30,
-        "Notification of log for `test/targets-interpolated' FAILED or TIMED OUT",
+        "Notification failed or timed out. service=log, topic=test/targets-interpolated",
     ) in caplog.record_tuples

--- a/tests/services/test_noop.py
+++ b/tests/services/test_noop.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# (c) 2023 The mqttwarn developers
+from mqttwarn.model import ProcessorItem
+from mqttwarn.util import load_module_by_name
+
+
+def test_noop_success(srv, caplog):
+    module = load_module_by_name("mqttwarn.services.noop")
+
+    item = ProcessorItem()
+    outcome = module.plugin(srv, item)
+
+    assert outcome is True
+    assert "Successfully sent message using noop" in caplog.messages
+
+
+def test_noop_failure(srv, caplog):
+    module = load_module_by_name("mqttwarn.services.noop")
+
+    item = ProcessorItem(message="fail")
+    outcome = module.plugin(srv, item)
+
+    assert outcome is False
+    assert "Failed sending message using noop" in caplog.messages

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -37,7 +37,6 @@ def test_config_notls_is_default():
     assert config.tls is False
 
 
-# FIXME: Adding `sslv3` raises `AttributeError: module 'ssl' has no attribute 'PROTOCOL_SSLv3'`.
 @pytest.mark.parametrize("tls_version", ["tlsv1", "tlsv1_1", "tlsv1_2"])
 def test_config_tls_active(tls_version):
     """

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 # (c) 2022 The mqttwarn developers
+from unittest.mock import Mock
+
 import pytest
 
 from mqttwarn.configuration import Config
@@ -87,7 +89,7 @@ def test_runtime_context_callfunc_failures(caplog, runtime_ini_file):
     ]
 
 
-def test_runtime_context_get_service_config(runtime_ini_file):
+def test_runtime_context_get_service_config_success(runtime_ini_file):
     """
     Verify the `RuntimeContext.get_service_config` method.
     """
@@ -99,7 +101,25 @@ def test_runtime_context_get_service_config(runtime_ini_file):
         "filter": "filter_function()",
         "qos": 1,
     }
-    assert context.get_service_config("unknown") == {}
+
+
+def test_runtime_context_get_service_config_empty():
+    """
+    Verify the `RuntimeContext.get_service_config` method, when the result is an empty dictionary.
+    """
+    context = RuntimeContext(config=Mock(config=Mock(return_value=None)), invoker=None)
+    assert context.get_service_config("foo") == {}
+
+
+def test_runtime_context_get_service_config_unknown(runtime_ini_file):
+    """
+    Verify the `RuntimeContext.get_service_config` method, when the configuration section does not exist.
+    """
+    config = Config(configuration_file=runtime_ini_file)
+    context = RuntimeContext(config=config, invoker=None)
+    with pytest.raises(KeyError) as ex:
+        context.get_service_config("unknown")
+    assert ex.match("Configuration section does not exist: config:unknown")
 
 
 def test_runtime_context_get_service_targets(runtime_ini_file):

--- a/tests/test_core_infra.py
+++ b/tests/test_core_infra.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-# (c) 2018-2022 The mqttwarn developers
+# (c) 2018-2023 The mqttwarn developers
 import configparser
+import re
 import socket
 import sys
 import threading
@@ -9,16 +10,22 @@ from unittest import mock
 from unittest.mock import Mock, call
 
 import pytest
+from paho.mqtt.client import Client as MqttClient
+from paho.mqtt.client import MQTTMessage
 
 from mqttwarn.configuration import Config
 from mqttwarn.context import RuntimeContext
 from mqttwarn.core import (
+    bootstrap,
     cleanup,
     connect,
+    load_services,
     on_connect,
     on_disconnect,
+    on_message,
     publish_status_information,
     render_template,
+    run_plugin,
     send_failover,
     subscribe_forever,
     xform,
@@ -27,7 +34,7 @@ from tests import configfile_empty_functions, configfile_full, configfile_no_fun
 from tests.util import core_bootstrap, delay, send_message
 
 
-def test_bootstrap(caplog):
+def test_bootstrap_success(caplog):
     """
     Verify the test utility bootstrapping function `core_bootstrap`.
     It will bootstrap the core machinery without MQTT.
@@ -142,7 +149,7 @@ def test_bootstrap_without_jinja2(without_jinja):
     assert mqttwarn.core.HAVE_JINJA is False
 
 
-def test_connect_success(mocker, caplog):
+def test_connect_basic_success(mocker, caplog):
     """
     Verify the `connect()` function succeeds.
     """
@@ -170,6 +177,82 @@ def test_connect_success(mocker, caplog):
         "Expecting a list in section `defaults', key `launch' (No section: 'defaults')",
     ) in caplog.record_tuples
     assert ("mqttwarn.core", 30, "No services defined") in caplog.record_tuples
+
+
+def test_connect_auth_success(mocker, caplog):
+    """
+    Verify the `connect()` function does the right thing when requesting MQTT broker authentication.
+    """
+
+    # Use a real configuration object.
+    config = Config(defaults={"clientid": "testdrive"})
+    config.username = "foo"
+    config.password = None
+    mocker.patch("mqttwarn.core.cf", config)
+
+    # Use mocked MQTT client and mqttwarn context instances.
+    mqtt_client: Mock = mocker.patch("paho.mqtt.client.Client")
+    mqttwarn_context: Mock = mocker.patch("mqttwarn.core.context")
+
+    # Run the `connect` function to completion.
+    connect()
+
+    assert mqtt_client.mock_calls == [
+        call("testdrive", clean_session=False, protocol=3),
+        call().username_pw_set("foo", None),
+        call().connect("localhost", 1883, 60),
+    ]
+    assert mqttwarn_context.mock_calls == []
+
+
+def test_connect_tls_success(mocker, caplog):
+    """
+    Verify the `connect()` function does the right thing when requesting MQTT broker authentication.
+    """
+
+    # Use a real configuration object.
+    config = Config(defaults={"clientid": "testdrive"})
+    config.tls = True
+    mocker.patch("mqttwarn.core.cf", config)
+
+    # Use mocked MQTT client and mqttwarn context instances.
+    mqtt_client: Mock = mocker.patch("paho.mqtt.client.Client")
+    mqttwarn_context: Mock = mocker.patch("mqttwarn.core.context")
+
+    # Run the `connect` function to completion.
+    connect()
+
+    assert mqtt_client.mock_calls == [
+        call("testdrive", clean_session=False, protocol=3),
+        call().tls_set(None, None, None, tls_version=None, ciphers=None),
+        call().connect("localhost", 1883, 60),
+    ]
+    assert mqttwarn_context.mock_calls == []
+
+
+def test_connect_tls_insecure_success(mocker, caplog):
+    """
+    Verify the `connect()` function does the right thing when requesting MQTT broker authentication.
+    """
+
+    # Use a real configuration object.
+    config = Config(defaults={"clientid": "testdrive"})
+    config.tls_insecure = True
+    mocker.patch("mqttwarn.core.cf", config)
+
+    # Use mocked MQTT client and mqttwarn context instances.
+    mqtt_client: Mock = mocker.patch("paho.mqtt.client.Client")
+    mqttwarn_context: Mock = mocker.patch("mqttwarn.core.context")
+
+    # Run the `connect` function to completion.
+    connect()
+
+    assert mqtt_client.mock_calls == [
+        call("testdrive", clean_session=False, protocol=3),
+        call().tls_insecure_set(True),
+        call().connect("localhost", 1883, 60),
+    ]
+    assert mqttwarn_context.mock_calls == []
 
 
 def test_connect_connection_failure(mocker, caplog):
@@ -275,6 +358,26 @@ def test_on_disconnect_failure(mocker, caplog):
     send_failover.assert_called_once_with(
         "brokerdisconnected", b"Broker connection lost. Will attempt to reconnect in 5s"
     )
+
+
+def test_on_message_success():
+    """
+    Verify success path of `on_message`.
+    """
+    mosq = MqttClient()
+    msg = MQTTMessage()
+    on_message(mosq=mosq, userdata={}, msg=msg)
+
+
+def test_on_message_failure(caplog, mocker):
+    """
+    Verify error path of `on_message`.
+    """
+    mosq = MqttClient()
+    msg = MQTTMessage()
+    mocker.patch("mqttwarn.core.on_message_handler", side_effect=Exception)
+    on_message(mosq=mosq, userdata={}, msg=msg)
+    assert "Receiving and decoding MQTT message failed" in caplog.messages
 
 
 def test_send_failover_no_targets(mocker, caplog):
@@ -566,3 +669,130 @@ def test_publish_status_information_failure(mocker, caplog):
         ("mqttwarn.core", 20, "Publishing status information to mqttwarn/$SYS"),
         ("mqttwarn.core", 40, "Unable to publish status information"),
     ]
+
+
+def test_processor(tmp_ini, caplog):
+    """
+    Verify job dispatching w/o any target address information works (2021-10-18 [amo]).
+    """
+    import mqttwarn.core
+
+    mqttwarn.core.exit_flag = True
+    mqttwarn.core.processor()
+    assert "Worker thread exiting" in caplog.messages
+
+
+def test_load_services_success():
+    """
+    Verify loading a service without further ado succeeds.
+    """
+    config = Config()
+    config.add_section("config:noop")
+    bootstrap(config=config)
+    load_services(["noop"])
+
+
+def test_load_services_unknown():
+    """
+    Loading an unknown service should fail.
+    """
+    config = Config()
+    bootstrap(config=config)
+    with pytest.raises(KeyError) as ex:
+        load_services(["unknown"])
+    assert ex.match("Configuration section does not exist: config:unknown")
+
+
+def test_load_services_spec_not_found(caplog):
+    """
+    Loading a service where its module can not be discovered from a module specification, should fail.
+    """
+    config = Config()
+    config.add_section("config:foo.bar")
+    bootstrap(config=config)
+    with pytest.raises(SystemExit) as ex:
+        load_services(["foo.bar"])
+    assert 'Loading service "foo.bar" from module "foo.bar" failed' in caplog.messages
+    assert 'Unable to load service "foo.bar"' in caplog.messages
+    assert ex.match("1")
+
+
+def test_load_services_file_not_found(caplog):
+    """
+    Loading a service where its module can not be discovered from a file name path, should fail.
+    """
+    config = Config()
+    config.configuration_path = "/tmp"
+    config.add_section("config:foo.bar")
+    config.set("config:foo.bar", "module", "foo_bar.py")
+    bootstrap(config=config)
+    with pytest.raises(SystemExit) as ex:
+        load_services(["foo.bar"])
+    assert 'Module "foo_bar.py" is not a file' in caplog.messages
+    assert 'Module "/tmp/foo_bar.py" is not a file' in caplog.messages
+    assert 'Unable to load service "foo.bar"' in caplog.messages
+    assert ex.match("1")
+
+
+def test_load_services_file_failure(tmp_path, caplog):
+    """
+    When loading a module fails at runtime, mqttwarn should fail.
+    """
+
+    # Prepare a Python module which will raise an exception when loaded.
+    modulefile = tmp_path / "foo_bar.py"
+    modulefile.write_text("assert 1 == 2\n")
+
+    config = Config()
+    config.configuration_path = tmp_path
+    config.add_section("config:foo.bar")
+    config.set("config:foo.bar", "module", "foo_bar.py")
+    bootstrap(config=config)
+
+    with pytest.raises(SystemExit) as ex:
+        load_services(["foo.bar"])
+    assert re.match(r'.*Loading service "foo.bar" from file ".+/foo_bar.py" failed.*', caplog.text, re.DOTALL)
+    assert "AssertionError" in caplog.text
+    assert 'Unable to load service "foo.bar"' in caplog.messages
+    assert ex.match("1")
+
+
+def test_run_plugin_success(caplog):
+    """
+    Verify running a plugin standalone works well.
+    """
+    config = Config()
+    config.add_section("config:noop")
+    run_plugin(config=config, name="noop")
+    assert 'Successfully loaded service "noop"' in caplog.messages
+    assert "Successfully sent message using noop" in caplog.messages
+    assert "Plugin response: True" in caplog.messages
+
+
+def test_run_plugin_failure(caplog):
+    """
+    Verify running a plugin standalone works well, and runtime failures will be signalled properly.
+    """
+    config = Config()
+    config.add_section("config:noop")
+    with pytest.raises(SystemExit) as ex:
+        run_plugin(config=config, name="noop", message="fail")
+    assert ex.match("1")
+
+    assert 'Successfully loaded service "noop"' in caplog.messages
+    assert "Failed sending message using noop" in caplog.messages
+    assert "Plugin response: False" in caplog.messages
+
+
+def test_run_plugin_module_success(caplog):
+    """
+    Verify running a plugin standalone works well, when addressing it as a full-qualified module name.
+    """
+    config = Config()
+    config.add_section("config:mqttwarn.services.noop")
+    run_plugin(config=config, name="mqttwarn.services.noop")
+    assert (
+        'Successfully loaded service "mqttwarn.services.noop" from module "mqttwarn.services.noop"' in caplog.messages
+    )
+    assert "Successfully sent message using noop" in caplog.messages
+    assert "Plugin response: True" in caplog.messages

--- a/tests/test_core_job.py
+++ b/tests/test_core_job.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+# (c) 2018-2023 The mqttwarn developers
+from mqttwarn.core import process_job
+from mqttwarn.model import ProcessorItem
+from tests.util import core_bootstrap
+
+
+def test_process_job_without_target_addrs(tmp_ini, caplog):
+    """
+    Verify job dispatching w/o any target address information works (2021-10-18 [amo]).
+    """
+
+    tmp_ini.write_text(
+        """
+[defaults]
+launch = noop
+
+[config:noop]
+    """
+    )
+
+    # Bootstrap the core machinery without MQTT.
+    core_bootstrap(configfile=tmp_ini)
+
+    # Define and process the job.
+    item = ProcessorItem(
+        service="noop",
+        target=None,
+        message="foo",
+        data={},
+    )
+    process_job(item.to_job())
+
+    assert "Successfully sent message using noop" in caplog.messages
+
+
+def test_process_job_with_invalid_priority(tmp_ini, caplog):
+    """
+    Verify invalid topic priority will emit a corresponding warning.
+    """
+
+    tmp_ini.write_text(
+        """
+[defaults]
+launch = noop
+
+[config:noop]
+
+[testdrive/invalid-priority]
+priority = invalid
+    """
+    )
+
+    # Bootstrap the core machinery without MQTT.
+    core_bootstrap(configfile=tmp_ini)
+
+    # Define and process the job.
+    item = ProcessorItem(
+        service="noop",
+        target=None,
+        section="testdrive/invalid-priority",
+        message="foo",
+        data={},
+    )
+    process_job(item.to_job())
+
+    assert "Failed to determine the priority, defaulting to zero" in caplog.messages
+    assert "ValueError: invalid literal for int() with base 10: 'invalid'" in caplog.text
+
+
+def test_process_job_with_failing_template_rendering(tmp_ini, caplog):
+    """
+    When rendering a template fails, a corresponding warning should be emitted.
+    """
+
+    tmp_ini.write_text(
+        """
+[defaults]
+launch = noop
+
+[config:noop]
+
+[testdrive/template]
+template = unknown.jinja
+targets = noop
+    """
+    )
+
+    # Bootstrap the core machinery without MQTT.
+    core_bootstrap(configfile=tmp_ini)
+
+    # Define and process the job.
+    item = ProcessorItem(
+        service="noop",
+        target=None,
+        section="testdrive/template",
+        message="foo",
+        data={},
+    )
+    process_job(item.to_job())
+
+    assert "Rendering template failed: unknown.jinja" in caplog.messages
+    assert "TemplateNotFound: unknown.jinja" in caplog.text
+
+
+def test_process_job_with_empty_payload_is_suppressed(tmp_ini, caplog):
+    """
+    Verify job dispatching with an empty message payload will suppress it.
+    """
+
+    tmp_ini.write_text(
+        """
+[defaults]
+launch = noop
+
+[config:noop]
+    """
+    )
+
+    # Bootstrap the core machinery without MQTT.
+    core_bootstrap(configfile=tmp_ini)
+
+    # Define and process the job.
+    item = ProcessorItem(
+        service="noop",
+        target=None,
+        message="",
+        data={},
+    )
+    process_job(item.to_job())
+
+    assert "Notification suppressed. Reason: Payload is empty. service=noop, topic=None" in caplog.messages

--- a/tests/test_core_main.py
+++ b/tests/test_core_main.py
@@ -3,6 +3,7 @@
 import io
 import json
 import os
+import sys
 import tempfile
 
 import pytest
@@ -666,6 +667,7 @@ targets = example:{name}
     send_message(topic="test/target-interpolate", payload=json.dumps({"name": "foobar"}))
 
 
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="This test only works on Python >= 3.7")
 def test_targets_service_interpolation_failure(tmp_ini, caplog):
     """
     When interpolating transformation data values into topic targets, and it fails,

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -115,7 +115,7 @@ def test_system_dispatch_to_log_service_plaintext(mosquitto, caplog, capmqtt):
     assert "Message on test/log-1 going to log:info" in caplog.messages
     assert "New `log:info' job: test/log-1" in caplog.messages
     assert "Processor #0 is handling: `log' for info" in caplog.messages
-    assert "Formatting message with function '{name}: {value}' failed" in caplog.messages
+    assert "Formatting message with function failed: {name}: {value}" in caplog.messages
     assert "Invoking service plugin for `log'" in caplog.messages
     assert ("mqttwarn.services.log", 20, "foobar") in caplog.record_tuples
     assert "Job queue has 0 items to process" in caplog.messages

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3,7 +3,7 @@
 from copy import deepcopy
 
 from mqttwarn.core import make_service
-from mqttwarn.model import Job, Struct
+from mqttwarn.model import Job, ProcessorItem, Struct
 
 JOB_PRIO1 = dict(
     prio=1, service="service", section="section", topic="topic", payload="payload", data="data", target="target"
@@ -60,3 +60,20 @@ def test_struct():
     assert struct.get("unknown", default=42) == 42
     assert repr(struct) == "<hello: 'world'>"
     assert struct.enum() == data
+
+
+def test_processoritem():
+    item = ProcessorItem()
+    assert item.asdict() == {
+        "service": None,
+        "target": None,
+        "config": {},
+        "addrs": [],
+        "priority": None,
+        "section": None,
+        "topic": None,
+        "title": None,
+        "message": None,
+        "data": None,
+    }
+    assert item.get("foo") is None

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -14,6 +14,7 @@ from mqttwarn.util import (
     asbool,
     get_resource_content,
     import_module,
+    load_file,
     load_function,
     load_functions,
     load_module_by_name,
@@ -190,3 +191,15 @@ def test_import_module():
 
     symbol = import_module("mqttwarn.services.log.plugin")
     assert symbol.__name__ == "plugin"
+
+
+def test_load_file_success(tmp_path):
+    tmpfile = tmp_path / "foo.txt"
+    tmpfile.write_text("Hello, world.")
+    payload = load_file(tmpfile)
+    assert payload.read() == b"Hello, world."
+
+
+def test_load_file_failure(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        load_file("/tmp/foobar.txt", retry_tries=0)

--- a/tests/util.py
+++ b/tests/util.py
@@ -53,7 +53,7 @@ def send_message(topic=None, payload=None, retain=False):
     delay()
 
 
-def delay(seconds=0.05):
+def delay(seconds=0.075):
     """
     Wait for designated number of seconds.
     """


### PR DESCRIPTION
Sleeves up. After all the documentation improvements, this patch aims to sand a few edges, and to bring code coverage for the mqttwarn core machinery to ~100%, increasing the coverage for `mqttwarn.core` itself by 7.5%.

![image](https://user-images.githubusercontent.com/453543/236677638-d8ca304d-e5b6-4901-a40d-4471b6d323bb.png)
