### PR TITLE
Chore: Adjust links after repository transfer

### DIFF
--- a/.github/workflows/release-docker-full.yml
+++ b/.github/workflows/release-docker-full.yml
@@ -24,7 +24,7 @@ concurrency:
 
 # The name for the produced image at ghcr.io.
 env:
-  GHCR_IMAGE_NAME: jpmens/mqttwarn-full
+  GHCR_IMAGE_NAME: mqtt-tools/mqttwarn-full
 
 jobs:
   docker:

--- a/.github/workflows/release-docker-standard.yml
+++ b/.github/workflows/release-docker-standard.yml
@@ -24,7 +24,7 @@ concurrency:
 
 # The name for the produced image at ghcr.io.
 env:
-  GHCR_IMAGE_NAME: jpmens/mqttwarn-standard
+  GHCR_IMAGE_NAME: mqtt-tools/mqttwarn-standard
 
 jobs:
   docker:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,8 +17,8 @@ date-published: 2014-02-09
 date-released: 2023-04-13
 type: software
 license: EPL
-license-url: https://github.com/jpmens/mqttwarn/blob/main/LICENSE
-repository-code: https://github.com/jpmens/mqttwarn
+license-url: https://github.com/mqtt-tools/mqttwarn/blob/main/LICENSE
+repository-code: https://github.com/mqtt-tools/mqttwarn
 keywords:
   - acquisition
   - data

--- a/Dockerfile.mqttwarn-slack
+++ b/Dockerfile.mqttwarn-slack
@@ -1,5 +1,4 @@
 # Docker build file for mqttwarn, with Slack SDK.
-# Based on https://hub.docker.com/r/jpmens/mqttwarn.
 #
 # Invoke like:
 #
@@ -7,7 +6,7 @@
 #
 
 # Derive from upstream image.
-FROM ghcr.io/jpmens/mqttwarn-standard:latest
+FROM ghcr.io/mqtt-tools/mqttwarn-standard:latest
 
 # Make package installation run as "root" user
 USER root

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
-.. image:: https://github.com/jpmens/mqttwarn/workflows/Tests/badge.svg
-    :target: https://github.com/jpmens/mqttwarn/actions?workflow=Tests
+.. image:: https://github.com/mqtt-tools/mqttwarn/workflows/Tests/badge.svg
+    :target: https://github.com/mqtt-tools/mqttwarn/actions?workflow=Tests
 
-.. image:: https://codecov.io/gh/jpmens/mqttwarn/branch/main/graph/badge.svg
-    :target: https://codecov.io/gh/jpmens/mqttwarn
+.. image:: https://codecov.io/gh/mqtt-tools/mqttwarn/branch/main/graph/badge.svg
+    :target: https://codecov.io/gh/mqtt-tools/mqttwarn
 
 .. image:: https://img.shields.io/pypi/pyversions/mqttwarn.svg
     :target: https://pypi.org/project/mqttwarn/
@@ -19,11 +19,11 @@
 .. image:: https://pepy.tech/badge/mqttwarn/month
     :target: https://pepy.tech/project/mqttwarn
 
-`GitHub <https://github.com/jpmens/mqttwarn>`_
+`GitHub <https://github.com/mqtt-tools/mqttwarn>`_
 | `PyPI <https://pypi.org/project/mqttwarn/>`_
 | `Documentation <https://mqttwarn.readthedocs.io>`_
-| `Issues <https://github.com/jpmens/mqttwarn/issues>`_
-| `Changelog <https://github.com/jpmens/mqttwarn/blob/main/CHANGES.rst>`_
+| `Issues <https://github.com/mqtt-tools/mqttwarn/issues>`_
+| `Changelog <https://github.com/mqtt-tools/mqttwarn/blob/main/CHANGES.rst>`_
 
 |
 
@@ -35,7 +35,7 @@ mqttwarn
 
 To *warn*, *alert*, or *notify*.
 
-.. image:: https://raw.githubusercontent.com/jpmens/mqttwarn/main/assets/google-definition.jpg
+.. image:: https://raw.githubusercontent.com/mqtt-tools/mqttwarn/main/assets/google-definition.jpg
 
 
 
@@ -55,7 +55,7 @@ sophisticated transformations.
 
 A picture says a thousand words.
 
-.. image:: https://raw.githubusercontent.com/jpmens/mqttwarn/main/assets/mqttwarn.png
+.. image:: https://raw.githubusercontent.com/mqtt-tools/mqttwarn/main/assets/mqttwarn.png
     :target: #
 
 
@@ -111,8 +111,8 @@ For running ``mqttwarn`` on a container infrastructure like Docker or
 Kubernetes, corresponding images are automatically published to the
 GitHub Container Registry (GHCR).
 
-- ``ghcr.io/jpmens/mqttwarn-standard:latest``
-- ``ghcr.io/jpmens/mqttwarn-full:latest``
+- ``ghcr.io/mqtt-tools/mqttwarn-standard:latest``
+- ``ghcr.io/mqtt-tools/mqttwarn-full:latest``
 
 To learn more about this topic, please follow up reading the `Using the OCI image
 with Docker or Podman`_ documentation section.
@@ -178,7 +178,7 @@ About
 =====
 These links will guide you to the source code of *mqttwarn* and its documentation.
 
-- `mqttwarn on GitHub <https://github.com/jpmens/mqttwarn>`_
+- `mqttwarn on GitHub <https://github.com/mqtt-tools/mqttwarn>`_
 - `mqttwarn on the Python Package Index (PyPI) <https://pypi.org/project/mqttwarn/>`_
 - `mqttwarn documentation <https://mqttwarn.readthedocs.io/>`_
 
@@ -249,23 +249,23 @@ Have fun!
 
 .. _Apprise: https://github.com/caronc/apprise
 .. _Apprise notification services: https://github.com/caronc/apprise/wiki#notification-services
-.. _backlog: https://github.com/jpmens/mqttwarn/blob/main/doc/backlog.rst
+.. _backlog: https://github.com/mqtt-tools/mqttwarn/blob/main/doc/backlog.rst
 .. _Eclipse Mosquitto: https://mosquitto.org
 .. _EPL-2.0: https://www.eclipse.org/legal/epl-2.0/
-.. _hacking: https://github.com/jpmens/mqttwarn/blob/main/doc/hacking.rst
+.. _hacking: https://github.com/mqtt-tools/mqttwarn/blob/main/doc/hacking.rst
 .. _How do your servers talk to you?: https://jpmens.net/2014/04/03/how-do-your-servers-talk-to-you/
 .. _Installing mqttwarn with pip: https://mqttwarn.readthedocs.io/en/latest/usage/pip.html
-.. _issue: https://github.com/jpmens/mqttwarn/issues/new
-.. _LICENSE: https://github.com/jpmens/mqttwarn/blob/main/LICENSE
+.. _issue: https://github.com/mqtt-tools/mqttwarn/issues/new
+.. _LICENSE: https://github.com/mqtt-tools/mqttwarn/blob/main/LICENSE
 .. _MQTTwarn\: Ein Rundum-Sorglos-Notifier: https://web.archive.org/web/20140611040637/http://jaxenter.de/news/MQTTwarn-Ein-Rundum-Sorglos-Notifier-171312
 .. _mqttwarn configuration: https://mqttwarn.readthedocs.io/en/latest/configure/
 .. _mqttwarn development sandbox: https://mqttwarn.readthedocs.io/en/latest/workbench/sandbox.html
 .. _mqttwarn documentation: https://mqttwarn.readthedocs.io/
 .. _mqttwarn notifier catalog: https://mqttwarn.readthedocs.io/en/latest/notifier-catalog.html
-.. _mqttwarn.service: https://github.com/jpmens/mqttwarn/blob/main/etc/mqttwarn.service
-.. _opening an issue on GitHub: https://github.com/jpmens/mqttwarn/issues/new
+.. _mqttwarn.service: https://github.com/mqtt-tools/mqttwarn/blob/main/etc/mqttwarn.service
+.. _opening an issue on GitHub: https://github.com/mqtt-tools/mqttwarn/issues/new
 .. _Running notification plugins standalone: https://mqttwarn.readthedocs.io/en/latest/usage/standalone.html
 .. _Schwarmalarm using mqttwarn: https://hiveeyes.org/docs/system/schwarmalarm-mqttwarn.html
 .. _Supervisor: https://jpmens.net/2014/02/13/in-my-toolbox-supervisord/
-.. _supervisor.ini: https://github.com/jpmens/mqttwarn/blob/main/etc/supervisor.ini
+.. _supervisor.ini: https://github.com/mqtt-tools/mqttwarn/blob/main/etc/supervisor.ini
 .. _Using the OCI image with Docker or Podman: https://mqttwarn.readthedocs.io/en/latest/usage/oci.html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,13 @@
 # To use this Docker Compose file for mqttwarn:
 #
 # 1. Acquire "docker-compose.yml":
-# wget https://raw.githubusercontent.com/jpmens/mqttwarn/main/docker-compose.yml
+# wget https://raw.githubusercontent.com/mqtt-tools/mqttwarn/main/docker-compose.yml
 #
 # 2. Create a directory for mqttwarn to store "mqttwarn.ini" and "funcs.py" in:
 # mkdir /path/to/mqttwarn
 #
 # 3. Acquire "mqttwarn.ini":
-# wget https://raw.githubusercontent.com/jpmens/mqttwarn/main/mqttwarn/examples/basic/mqttwarn.ini -O /path/to/mqtwarn/mqttwarn.ini
+# wget https://raw.githubusercontent.com/mqtt-tools/mqttwarn/main/mqttwarn/examples/basic/mqttwarn.ini -O /path/to/mqtwarn/mqttwarn.ini
 #
 # 4. Define the location to the custom functions file within "mqttwarn.ini":
 #
@@ -16,7 +16,7 @@ version: '3'
 
 services:
   mqttwarn:
-    image: ghcr.io/jpmens/mqttwarn-full:latest
+    image: ghcr.io/mqtt-tools/mqttwarn-full:latest
     container_name: mqttwarn
     restart: always
     volumes:

--- a/docs/configure/index.rst
+++ b/docs/configure/index.rst
@@ -70,5 +70,5 @@ defining how messages will be filtered, decoded, and re-formatted while
 mqttwarn is processing them.
 
 
-.. _mqttwarn.ini: https://github.com/jpmens/mqttwarn/blob/main/mqttwarn/examples/basic/mqttwarn.ini
-.. _udf.py: https://github.com/jpmens/mqttwarn/blob/main/mqttwarn/examples/basic/udf.py
+.. _mqttwarn.ini: https://github.com/mqtt-tools/mqttwarn/blob/main/mqttwarn/examples/basic/mqttwarn.ini
+.. _udf.py: https://github.com/mqtt-tools/mqttwarn/blob/main/mqttwarn/examples/basic/udf.py

--- a/docs/configure/service.md
+++ b/docs/configure/service.md
@@ -246,6 +246,6 @@ item = {
 ```
 
 
-[mqttwarn/services]: https://github.com/jpmens/mqttwarn/tree/main/mqttwarn/services
+[mqttwarn/services]: https://github.com/mqtt-tools/mqttwarn/tree/main/mqttwarn/services
 [`PYTHONPATH`]: https://docs.python.org/3/using/cmdline.html#envvar-PYTHONPATH
 [`sys.path`]: https://docs.python.org/3/library/sys.html#sys.path

--- a/docs/configure/topic.md
+++ b/docs/configure/topic.md
@@ -170,5 +170,5 @@ targets = store-image:{camera}-{label}
 ```
 
 
-[incorporate topic names into topic targets]: https://github.com/jpmens/mqttwarn/wiki/Incorporating-topic-names#incorporate-topic-names-into-topic-targets
+[incorporate topic names into topic targets]: https://github.com/mqtt-tools/mqttwarn/wiki/Incorporating-topic-names#incorporate-topic-names-into-topic-targets
 [`mosquitto_pub`]: https://mosquitto.org/man/mosquitto_pub-1.html

--- a/docs/configure/transformation.md
+++ b/docs/configure/transformation.md
@@ -212,7 +212,7 @@ where you pick values of interest from your nested JSON document.
 
 :::{todo}
 We are looking into providing a generic way to access nested elements at 
-[access nested elements in JSON payloads](https://github.com/jpmens/mqttwarn/issues/303).
+[access nested elements in JSON payloads](https://github.com/mqtt-tools/mqttwarn/issues/303).
 In the meanwhile, for doing it in a custom way, please have a look at the
 (#nested-json-example).
 :::

--- a/docs/notifier-catalog.md
+++ b/docs/notifier-catalog.md
@@ -1203,7 +1203,7 @@ to InfluxDB 2.x, contributions to [Support for InfluxDB 2 #563] are very much
 welcome.
 :::
 
-[Support for InfluxDB 2 #563]: https://github.com/jpmens/mqttwarn/issues/563
+[Support for InfluxDB 2 #563]: https://github.com/mqtt-tools/mqttwarn/issues/563
 
 
 ### `irccat`
@@ -1545,7 +1545,7 @@ When a message is received, the plugin will attempt to populate the following co
   - e.g. `name` and `id` above
 - Names for [transformation data fields](#transformations)
   - e.g. `topic`, `payload` and `_dtiso` as above
-  - note that these all must be `VARCHAR` columns; timestamp columns are [not yet supported](https://github.com/jpmens/mqttwarn/issues/334#issuecomment-422141808)
+  - note that these all must be `VARCHAR` columns; timestamp columns are [not yet supported](https://github.com/mqtt-tools/mqttwarn/issues/334#issuecomment-422141808)
 - the _fallbackcolumn_, as noted below
 
 To be clear, there is no other way to configure this particular plugin to use different
@@ -3054,7 +3054,7 @@ Please make sure the four credential values are specified in the correct order.
 :::
 :::{todo}
 This is a perfect candidate to use [named target address descriptor options] instead. 
-[named target address descriptor options]: https://github.com/jpmens/mqttwarn/issues/628
+[named target address descriptor options]: https://github.com/mqtt-tools/mqttwarn/issues/628
 :::
 
 [Twitter]: https://twitter.com
@@ -3098,7 +3098,7 @@ targets = {
 | Topic option  |  M/O   | Description                            |
 | ------------- | :----: | -------------------------------------- |
 | `title`       |   O    | notification title                     |
-| `image`       |   O    | notification image URL  ([example](https://github.com/jpmens/mqttwarn/issues/53#issuecomment-39691429))|
+| `image`       |   O    | notification image URL  ([example](https://github.com/mqtt-tools/mqttwarn/issues/53#issuecomment-39691429))|
 
 [Kodi]: https://kodi.tv/
 [XBMC]: https://en.wikipedia.org/wiki/Xbmc#History
@@ -3237,7 +3237,7 @@ For another scenario using the `zabbix` plugin, please refer to the [Zabbix IoT 
 
 
 [Zabbix]: https://www.zabbix.com/
-[Zabbix IoT example]: https://github.com/jpmens/mqttwarn/tree/main/examples/zabbix-iot
+[Zabbix IoT example]: https://github.com/mqtt-tools/mqttwarn/tree/main/examples/zabbix-iot
 [Zabbix low-level discovery]: https://www.zabbix.com/documentation/current/en/manual/discovery/low_level_discovery
 [Zabbix meets MQTT]: http://jpmens.net/2014/05/27/zabbix-meets-mqtt/
 [Zabbix trapper]: https://www.zabbix.com/documentation/current/en/manual/config/items/itemtypes/trapper

--- a/docs/usage/freebsd.md
+++ b/docs/usage/freebsd.md
@@ -42,4 +42,4 @@ pip install pyserial slixmpp
 [py-pyserial]: https://www.freshports.org/comms/py-pyserial/
 [py-slixmpp]: https://www.freshports.org/net-im/py-slixmpp/
 [Python package index]: https://pypi.org/
-[`setup.py`]: https://github.com/jpmens/mqttwarn/blob/main/setup.py
+[`setup.py`]: https://github.com/mqtt-tools/mqttwarn/blob/main/setup.py

--- a/docs/usage/oci.md
+++ b/docs/usage/oci.md
@@ -9,18 +9,18 @@ interactively, perhaps to help diagnose a problem.
 
 OCI images are available at:
 
-- https://github.com/orgs/jpmens/packages/container/package/mqttwarn-standard
-- https://github.com/orgs/jpmens/packages/container/package/mqttwarn-full
+- https://github.com/orgs/mqtt-tools/packages/container/package/mqttwarn-standard
+- https://github.com/orgs/mqtt-tools/packages/container/package/mqttwarn-full
 
 ## Choosing the OCI image
 
 Choose one of those OCI images.
 ```shell
 # The standard image on GHCR.
-export IMAGE=ghcr.io/jpmens/mqttwarn-standard:latest
+export IMAGE=ghcr.io/mqtt-tools/mqttwarn-standard:latest
 
 # The full image on GHCR.
-export IMAGE=ghcr.io/jpmens/mqttwarn-full:latest
+export IMAGE=ghcr.io/mqtt-tools/mqttwarn-full:latest
 ```
 
 ## Interactively
@@ -189,7 +189,7 @@ images.
 
 In order to use `mqttwarn` with additional Python modules not included in the
 baseline image, you will need to build custom OCI images based on the
-canonical `ghcr.io/jpmens/mqttwarn-standard:latest`.
+canonical `ghcr.io/mqtt-tools/mqttwarn-standard:latest`.
 
 We prepared an example which outlines how this would work with the Slack SDK.
 By using the `Dockerfile.mqttwarn-slack`, this command will build an OCI
@@ -203,18 +203,18 @@ docker build --tag=mqttwarn-slack --file=Dockerfile.mqttwarn-slack .
 
 If you prefer not to fiddle with those details, but instead want to run a full
 image including dependencies for all modules, we have you covered. Alongside
-the standard image, there is also `ghcr.io/jpmens/mqttwarn-full:latest`.
+the standard image, there is also `ghcr.io/mqtt-tools/mqttwarn-full:latest`.
 
 ## Image sizes
 
 We determined the **compressed** image sizes using [dockersize]::
 
-    $ dockersize ghcr.io/jpmens/mqttwarn-standard:latest
+    $ dockersize ghcr.io/mqtt-tools/mqttwarn-standard:latest
     linux/amd64   172.89M
     linux/arm64   167.12M
     linux/arm/v7  143.39M
 
-    $ dockersize ghcr.io/jpmens/mqttwarn-full:latest
+    $ dockersize ghcr.io/mqtt-tools/mqttwarn-full:latest
     linux/amd64   205.96M
     linux/arm64   186.81M
     linux/arm/v7  160.47M

--- a/docs/workbench/backlog.rst
+++ b/docs/workbench/backlog.rst
@@ -10,7 +10,7 @@ Iteration +1
 Bugs
 ====
 - [o] Documentation vs. code: Clarify and/or fix logic of "filter" function
-  https://github.com/jpmens/mqttwarn/issues/637
+  https://github.com/mqtt-tools/mqttwarn/issues/637
 
 Features
 ========
@@ -25,7 +25,7 @@ Maintenance
 Documentation » Tech
 ====================
 - [x] Add documentation on RTD
-  https://github.com/jpmens/mqttwarn/issues/389#issuecomment-1428353079
+  https://github.com/mqtt-tools/mqttwarn/issues/389#issuecomment-1428353079
 - [x] ogp-metadata-plugin
 - [x] sphinx-copybutton
 - [x] sphinx-autodoc
@@ -56,7 +56,7 @@ Documentation » Content
 - [o] Improve default output for ``mqttwarn make-udf``, ``basic/udf.py``.
 - [o] Deprecate the ``datamap`` function. ``alldata`` is the new thing.
 - [o] Screen the Wiki for more content
-  https://github.com/jpmens/mqttwarn/wiki/Incorporating-topic-names#incorporate-topic-names-into-topic-targets
+  https://github.com/mqtt-tools/mqttwarn/wiki/Incorporating-topic-names#incorporate-topic-names-into-topic-targets
 - [o] Naming things: "Transforming" is actually "Decoding"
 - [o] Add example from https://jpmens.net/2018/03/25/alerting-on-ssh-logins/
 - [o] Add "Acknowledgements" section
@@ -111,7 +111,7 @@ Iteration +2
 - [o] Adapt configuration for Supervisor and systemd
 - [o] Improve documentation: Add a complete roundtrip example involving ``mosquitto_pub``
 - [o] Improve documentation: Add "credits" section. At least add the author of Mosquitto.
-- [o] Add ``mqttwarn make-pubs`` or ``mqttwarn selftest``, see https://github.com/jpmens/mqttwarn/issues/127#issuecomment-381690557
+- [o] Add ``mqttwarn make-pubs`` or ``mqttwarn selftest``, see https://github.com/mqtt-tools/mqttwarn/issues/127#issuecomment-381690557
 - [o] Improve logging: Let "file" service report about where it's writing to
 
 
@@ -174,7 +174,7 @@ Goals for 2.0.0
             """
             return snippet
 - [o] Think about adding further support for plugins, e.g. for provisioning databases appropriately, see also
-  https://github.com/jpmens/mqttwarn/issues/283
+  https://github.com/mqtt-tools/mqttwarn/issues/283
 - [o] Configuration and source tree file watcher like ``pserve ... --reload``
 
 

--- a/docs/workbench/sandbox.rst
+++ b/docs/workbench/sandbox.rst
@@ -13,7 +13,7 @@ For hacking on mqttwarn, please install it in development mode.
 
 Get hold of the sources, initialize a Python virtualenv, and run the software tests::
 
-    git clone https://github.com/jpmens/mqttwarn
+    git clone https://github.com/mqtt-tools/mqttwarn
     cd mqttwarn
     make test
 

--- a/etc/mqttwarn.service
+++ b/etc/mqttwarn.service
@@ -40,7 +40,7 @@
 
 [Unit]
 Description=mqttwarn pluggable mqtt notification service
-Documentation=https://github.com/jpmens/mqttwarn
+Documentation=https://github.com/mqtt-tools/mqttwarn
 After=network.target
 
 [Service]

--- a/examples/frigate/README.rst
+++ b/examples/frigate/README.rst
@@ -70,7 +70,7 @@ Prerequisites
 
 Acquire sources and go to the right directory::
 
-    git clone https://github.com/jpmens/mqttwarn
+    git clone https://github.com/mqtt-tools/mqttwarn
     cd mqttwarn/examples/frigate
 
 
@@ -174,17 +174,17 @@ Example snapshot image
 .. _events in JSON format: https://docs.frigate.video/integrations/mqtt/#frigateevents
 .. _Frigate: https://frigate.video/
 .. _Frigate on GitHub: https://github.com/blakeblackshear/frigate
-.. _frigate.ini: https://github.com/jpmens/mqttwarn/blob/main/examples/frigate/frigate.ini
-.. _frigate.py: https://github.com/jpmens/mqttwarn/blob/main/examples/frigate/frigate.py
+.. _frigate.ini: https://github.com/mqtt-tools/mqttwarn/blob/main/examples/frigate/frigate.ini
+.. _frigate.py: https://github.com/mqtt-tools/mqttwarn/blob/main/examples/frigate/frigate.py
 .. _Jaromír Kalina: https://unsplash.com/@jkalinaofficial
 .. _Mosquitto on GitHub: https://github.com/eclipse/mosquitto
 .. _mqttwarn: https://mqttwarn.readthedocs.io/
-.. _mqttwarn on GitHub: https://github.com/jpmens/mqttwarn
+.. _mqttwarn on GitHub: https://github.com/mqtt-tools/mqttwarn
 .. _ntfy: https://ntfy.sh/
 .. _ntfy on GitHub: https://github.com/binwiederhier/ntfy
 .. _ntfy service plugin: https://mqttwarn.readthedocs.io/en/latest/notifier-catalog.html#ntfy
 .. _Philipp C. Heckel: https://github.com/binwiederhier
 .. _pub-sub: https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern
 .. _Sev: https://github.com/sevmonster
-.. _test_frigate.py: https://github.com/jpmens/mqttwarn/blob/main/examples/frigate/test_frigate.py
+.. _test_frigate.py: https://github.com/mqtt-tools/mqttwarn/blob/main/examples/frigate/test_frigate.py
 .. _Unsplash License: https://unsplash.com/license

--- a/examples/hiveeyes/hiveeyes.ini
+++ b/examples/hiveeyes/hiveeyes.ini
@@ -51,7 +51,7 @@ num_workers = 3
 ; Machinery
 ; =========
 
-; see also https://github.com/jpmens/mqttwarn/wiki/Incorporating-topic-names#incorporate-topic-names-into-topic-targets
+; see also https://github.com/mqtt-tools/mqttwarn/wiki/Incorporating-topic-names#incorporate-topic-names-into-topic-targets
 
 [hiveeyes-telemetry]
 ; Just log all incoming messages

--- a/examples/homie/homie.ini
+++ b/examples/homie/homie.ini
@@ -45,7 +45,7 @@ functions = 'examples.homie.homie'
 ; check_mk routing
 ; ================
 
-; See also https://github.com/jpmens/mqttwarn/wiki/Incorporating-topic-names#incorporate-topic-names-into-topic-targets
+; See also https://github.com/mqtt-tools/mqttwarn/wiki/Incorporating-topic-names#incorporate-topic-names-into-topic-targets
 
 [check_mk_universal]
 topic   = homie/+/+/value

--- a/examples/mediaplayer/readme.md
+++ b/examples/mediaplayer/readme.md
@@ -30,7 +30,7 @@ docker run --name=mosquitto -it --rm --publish=1883:1883 eclipse-mosquitto:2.0 m
 ```
 Let's acquire the `mqttwarn-mplayer.ini` configuration file, and start `mqttwarn`.
 ```shell
-wget https://github.com/jpmens/mqttwarn/raw/main/examples/mediaplayer/mqttwarn-mplayer.ini
+wget https://github.com/mqtt-tools/mqttwarn/raw/main/examples/mediaplayer/mqttwarn-mplayer.ini
 mqttwarn --config-file=mqttwarn-mplayer.ini
 ```
 Now, when publishing the URL to the audio resource on the designated MQTT topic, `mqttwarn` will

--- a/examples/zabbix-iot/README.md
+++ b/examples/zabbix-iot/README.md
@@ -53,8 +53,8 @@ docker run --name=mosquitto -it --rm --publish=1883:1883 eclipse-mosquitto:2.0 m
 
 Let's acquire the configuration assets, and start `mqttwarn`.
 ```shell
-wget https://github.com/jpmens/mqttwarn/raw/main/examples/zabbix-iot/mqttwarn-zabbix-iot.ini
-wget https://github.com/jpmens/mqttwarn/raw/main/examples/zabbix-iot/mqttwarn-zabbix-iot.py
+wget https://github.com/mqtt-tools/mqttwarn/raw/main/examples/zabbix-iot/mqttwarn-zabbix-iot.ini
+wget https://github.com/mqtt-tools/mqttwarn/raw/main/examples/zabbix-iot/mqttwarn-zabbix-iot.py
 mqttwarn --config-file=mqttwarn-zabbix-iot.ini
 ```
 

--- a/examples/zabbix-iot/readme.md
+++ b/examples/zabbix-iot/readme.md
@@ -53,8 +53,8 @@ docker run --name=mosquitto -it --rm --publish=1883:1883 eclipse-mosquitto:2.0 m
 
 Let's acquire the configuration assets, and start `mqttwarn`.
 ```shell
-wget https://github.com/jpmens/mqttwarn/raw/main/examples/zabbix-iot/mqttwarn-zabbix-iot.ini
-wget https://github.com/jpmens/mqttwarn/raw/main/examples/zabbix-iot/mqttwarn-zabbix-iot.py
+wget https://github.com/mqtt-tools/mqttwarn/raw/main/examples/zabbix-iot/mqttwarn-zabbix-iot.ini
+wget https://github.com/mqtt-tools/mqttwarn/raw/main/examples/zabbix-iot/mqttwarn-zabbix-iot.py
 mqttwarn --config-file=mqttwarn-zabbix-iot.ini
 ```
 

--- a/mqttwarn/services/alexa-notify-me.py
+++ b/mqttwarn/services/alexa-notify-me.py
@@ -5,7 +5,7 @@ __author__    = 'Bram Hendrickx'
 __copyright__ = 'Copyright 2016 Bram Hendrickx'
 __license__   = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)'
 
-Original script by Bram Hendrickx. https://github.com/jpmens/mqttwarn/blob/main/mqttwarn/services/ifttt.py
+Original script by Bram Hendrickx. https://github.com/mqtt-tools/mqttwarn/blob/main/mqttwarn/services/ifttt.py
 Modified to work with notify-me app for Alexa. http://www.thomptronics.com/notify-me
 """
 

--- a/mqttwarn/services/autoremote.py
+++ b/mqttwarn/services/autoremote.py
@@ -5,7 +5,7 @@ __author__    = 'Bram Hendrickx'
 __copyright__ = 'Copyright 2016 Bram Hendrickx'
 __license__   = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)'
 
-Original script by Bram Hendrickx. https://github.com/jpmens/mqttwarn/blob/main/mqttwarn/services/ifttt.py
+Original script by Bram Hendrickx. https://github.com/mqtt-tools/mqttwarn/blob/main/mqttwarn/services/ifttt.py
 Modified to work with the autoremote api https://joaoapps.com/autoremote/
 """
 

--- a/mqttwarn/services/hangbot.py
+++ b/mqttwarn/services/hangbot.py
@@ -5,7 +5,7 @@ __author__    = 'Bram Hendrickx'
 __copyright__ = 'Copyright 2016 Bram Hendrickx'
 __license__   = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)'
 
-Original script by Bram Hendrickx. https://github.com/jpmens/mqttwarn/blob/main/mqttwarn/services/ifttt.py
+Original script by Bram Hendrickx. https://github.com/mqtt-tools/mqttwarn/blob/main/mqttwarn/services/ifttt.py
 Modified to work with hangoutsbot api plugin https://github.com/hangoutsbot/hangoutsbot/wiki/API-Plugin
 """
 

--- a/mqttwarn/services/irccat.py
+++ b/mqttwarn/services/irccat.py
@@ -31,7 +31,7 @@ def plugin(srv, item):
     srv.logging.debug("Sending to IRCcat: %s" % (message))
 
     # Apparently, a trailing newline is needed.
-    # https://github.com/jpmens/mqttwarn/issues/547#issuecomment-944632712
+    # https://github.com/mqtt-tools/mqttwarn/issues/547#issuecomment-944632712
     message += "\n"
 
     try:

--- a/mqttwarn/services/rrdtool.py
+++ b/mqttwarn/services/rrdtool.py
@@ -23,7 +23,7 @@ def plugin(srv, item):
         # passed along to rrdtool
         # mofified by otfdr @ github to accept abitray arguments with
         # the payload and to not always add the 'N' in front
-        # 2017-06-05 - fix/enhancement for https://github.com/jpmens/mqttwarn/issues/248
+        # 2017-06-05 - fix/enhancement for https://github.com/mqtt-tools/mqttwarn/issues/248
         if re.match( "^\d+$", text ):
                 rrdtool.update(item.addrs, "N:" + text)
         else:

--- a/mqttwarn/util.py
+++ b/mqttwarn/util.py
@@ -34,7 +34,7 @@ class Formatter(string.Formatter):
         This also adds the '!j' conversion flag, which serializes the
         value to JSON format.
 
-        See also https://github.com/jpmens/mqttwarn/issues/146.
+        See also https://github.com/mqtt-tools/mqttwarn/issues/146.
         """
         if conversion == "j":
             value = json.dumps(value)

--- a/setup.py
+++ b/setup.py
@@ -222,7 +222,7 @@ setup(
     ],
     author="Jan-Piet Mens, Ben Jones, Andreas Motl",
     author_email="jpmens@gmail.com",
-    url="https://github.com/jpmens/mqttwarn",
+    url="https://github.com/mqtt-tools/mqttwarn",
     keywords="mqtt notification plugins data acquisition push transformation engine mosquitto",
     packages=find_packages(),
     include_package_data=True,

--- a/tests/fixtures/ntfy.py
+++ b/tests/fixtures/ntfy.py
@@ -46,7 +46,7 @@ class Ntfy(BaseImage):
         Image needs to be pulled explicitly.
         Workaround against `404 Client Error: Not Found for url: http+docker://localhost/v1.23/containers/create`.
 
-        - https://github.com/jpmens/mqttwarn/pull/589#issuecomment-1249680740
+        - https://github.com/mqtt-tools/mqttwarn/pull/589#issuecomment-1249680740
         - https://github.com/docker/docker-py/issues/2101
         """
         docker_client = docker.from_env(version=self.docker_version)


### PR DESCRIPTION
After transferring the repository to the `mqtt-tools` organization [^1], a few links and references needed to be adjusted.

[^1]: https://github.com/mqtt-tools/mqttwarn/issues/389#issuecomment-1537458335