### PR TITLE
Combine GitHub Pages configuration with RTD-hosted documentation

### DIFF
--- a/.github/docs-static/index.html
+++ b/.github/docs-static/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://mqttwarn.readthedocs.io/</title>
+<meta http-equiv="refresh" content="0; URL=https://mqttwarn.readthedocs.io/">
+<link rel="canonical" href="https://mqttwarn.readthedocs.io/">

--- a/.github/workflows/gh-pages-static.yml
+++ b/.github/workflows/gh-pages-static.yml
@@ -1,0 +1,42 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: '.github/docs-static'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+mqttwarn.readthedocs.io

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-www.mqttwarn.net


### PR DESCRIPTION
### About
An attempt to let http://www.mqttwarn.net/ redirect to https://mqttwarn.readthedocs.io/.

### Details
The _GitHub Pages_ settings at [^1] have been adjusted to build from the **repository root** instead of the `docs` subdirectory, which now contains a [Sphinx](https://www.sphinx-doc.org/) source tree instead of Jekyll, as before. As such, the `CNAME` control file has been moved to the repository root folder.

### References
- https://stackoverflow.com/questions/30167113/redirect-github-pages-to-custom-domain
- https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site

[^1]: https://github.com/mqtt-tools/mqttwarn/settings/pages