### PR TITLE
Fix sending ntfy notifications with longer messages than 76 characters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ mqttwarn changelog
 in progress
 ===========
 
+- Fix sending ntfy notifications with longer messages than 76 characters.
+  Thanks, @codebude.
+
 
 2023-05-15 0.34.1
 =================

--- a/mqttwarn/services/ntfy.py
+++ b/mqttwarn/services/ntfy.py
@@ -239,7 +239,7 @@ def encode_rfc2047(data: t.Union[str, bytes]) -> str:
     if isinstance(data, bytes):
         data = data.decode()
     if isinstance(data, str):
-        return Header(s=data, charset="utf-8").encode()
+        return Header(s=data, charset="utf-8", maxlinelen=10000).encode()
     else:
         raise TypeError(f"Unknown data type to compute ASCII-clean variant: {type(data).__name__}")
 

--- a/tests/services/test_ntfy.py
+++ b/tests/services/test_ntfy.py
@@ -346,3 +346,30 @@ def test_ntfy_plugin_api_failure(srv, caplog):
 
     assert outcome is False
     assert "Request to ntfy API failed" in caplog.messages
+
+
+@responses.activate
+def test_ntfy_long_message(srv, caplog):
+    """
+    Test submitting messages longer than 76 characters.
+    """
+
+    responses.add(
+        responses.PUT,
+        "http://localhost:9999/testdrive",
+        json={"not": "relevant"},
+        status=200,
+    )
+
+    module = load_module_by_name("mqttwarn.services.ntfy")
+
+    item = Item(
+        addrs={"url": "http://localhost:9999/testdrive"},
+        title="Gerät angelernt",
+        message="Das Gerät Kaffeevollautomat vom Typ Siemens TQ703D07 wurde angelernt",
+    )
+
+    outcome = module.plugin(srv, item)
+    assert outcome is True
+    assert "Successfully sent message using ntfy" in caplog.messages
+    assert "requests.exceptions.InvalidHeader" not in caplog.text


### PR DESCRIPTION
This patch addresses GH-672. Thanks, @codebude.