### PR TITLE
[Pushbullet]: Modernize service plugin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ in progress
 
 - Fix sending ntfy notifications with longer messages than 76 characters.
   Thanks, @codebude.
+- Modernize Pushbullet service plugin. Thanks, @DNicholai.
 
 
 2023-05-15 0.34.1

--- a/docs/notifier-catalog.md
+++ b/docs/notifier-catalog.md
@@ -2287,13 +2287,15 @@ targets = {
 
 ### `pushbullet`
 
-This service is for [PushBullet], an app for Android along with an extension for
+This service is for [Pushbullet], an app for Android along with an extension for
 Chrome and Firefox, which allows notes, links, pictures, addresses and files to be
-sent between devices. It is based on the [PushbulletPythonLibrary] package.
+sent between devices.
 
-You can get your API key from the [PushBullet account page] after signing up.
+You can get your API key from the [Pushbullet account page] after signing up, see
+also [Pushbullet » Getting an access token].
+
 You will also need the device ID to push the notifications to. To obtain this,
-you will need to follow the instructions at [pyPushBullet], by running
+you can, for example, follow the instructions at [pyPushBullet], by running
 ```shell
 ./pushbullet_cmd.py YOUR_API_KEY_HERE getdevices
 ```
@@ -2302,12 +2304,20 @@ The configuration layout looks like this.
 ```ini
 [config:pushbullet]
 targets = {
-                   # API KEY                  device ID     recipient_type
-    'warnme'   : [ 'xxxxxxxxxxxxxxxxxxxxxxx', 'yyyyyy',     'tttt' ]
+    "warnme"   : {
+        "access_token": "a6FJVAA0LVJKrT8k",
+        "recipient": "test@example.org",
+        "recipient_type": "email",
+        },
+    "alertme"   : {
+        "access_token": "a6FJVAA0LVJKrT8k",
+        "recipient": "ujpah72o0sjAoRtnM0jc",
+        },
     }
 ```
 
-The optional _recipient_type_ could be one of `device_iden` (default), `email`, `channel` or `client`.
+The optional _recipient_type_ could be one of `device` (default), `email`, `channel`
+or `client`. See also [Pushbullet target parameters].
 
 | Topic option  |  M/O   | Description                             |
 | ------------- | :----: |-----------------------------------------|
@@ -2315,10 +2325,16 @@ The optional _recipient_type_ could be one of `device_iden` (default), `email`, 
 
 ![Pushbullet](assets/pushbullet.jpg)
 
-[PushBullet]: https://www.pushbullet.com
-[PushBullet account page]: https://www.pushbullet.com/#settings/account
-[PushbulletPythonLibrary]: https://pypi.org/project/PushbulletPythonLibrary/
+[Pushbullet]: https://www.pushbullet.com
+[Pushbullet account page]: https://www.pushbullet.com/#settings/account
+[Pushbullet target parameters]: https://docs.pushbullet.com/#target-parameters
+[Pushbullet » Getting an access token]: https://docs.pushbullet.com/#getting-an-access-token
 [pyPushBullet]: https://github.com/Azelphur/pyPushBullet
+
+:::{note}
+The client currently only implements sending message with `type=note`. If you have a
+need to submit files or links, please let us know on the [mqttwarn issue tracker].
+:::
 
 
 ### `pushover`
@@ -3241,3 +3257,7 @@ For another scenario using the `zabbix` plugin, please refer to the [Zabbix IoT 
 [Zabbix low-level discovery]: https://www.zabbix.com/documentation/current/en/manual/discovery/low_level_discovery
 [Zabbix meets MQTT]: http://jpmens.net/2014/05/27/zabbix-meets-mqtt/
 [Zabbix trapper]: https://www.zabbix.com/documentation/current/en/manual/config/items/itemtypes/trapper
+
+
+
+[mqttwarn issue tracker]: https://github.com/mqtt-tools/mqttwarn/issues

--- a/mqttwarn/services/pushbullet.py
+++ b/mqttwarn/services/pushbullet.py
@@ -5,34 +5,74 @@ __author__    = 'Jan-Piet Mens <jpmens()gmail.com>'
 __copyright__ = 'Copyright 2014 Jan-Piet Mens'
 __license__   = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)'
 
-from pushbullet.pushbullet import PushBullet
+import requests
 
 
 def plugin(srv, item):
-    ''' expects (apikey, device_id) in adddrs '''
+    """
+    mqttwarn service for Pushbullet notifications.
+    """
 
     srv.logging.debug("*** MODULE=%s: service=%s, target=%s", __file__, item.service, item.target)
 
-    recipient_type = "device_iden"
-    try:
-        apikey, device_id = item.addrs
-    except:
+    # Decode target address descriptor.
+    if isinstance(item.addrs, list):
         try:
-            apikey, device_id, recipient_type = item.addrs
+            apikey, device_id = item.addrs
+            options = {"access_token": apikey, "recipient": device_id}
         except:
-            srv.logging.warn("pushbullet target is incorrectly configured")
-            return False
+            try:
+                apikey, device_id, recipient_type = item.addrs
+                options = {"access_token": apikey, "recipient": device_id, "recipient_type": recipient_type}
+            except:
+                raise ValueError("Pushbullet target is incorrectly configured")
+    elif isinstance(item.addrs, dict):
+        options = item.addrs
+    else:
+        raise ValueError(f"Unknown target address descriptor type: {type(item.addrs).__name__}")
 
+    # Assemble keyword arguments for `send_note` function.
     text = item.message
     title = item.get('title', srv.SCRIPTNAME)
+    options.update({"title": title, "body": text})
 
     try:
-        srv.logging.debug("Sending pushbullet notification to %s..." % (item.target))
-        pb = PushBullet(apikey)
-        pb.pushNote(device_id, title, text, recipient_type)
-        srv.logging.debug("Successfully sent pushbullet notification")
-    except Exception as e:
-        srv.logging.warning("Cannot notify pushbullet: %s" % e)
+        srv.logging.debug(f"Sending Pushbullet notification to {item.target}")
+        send_note(**options)
+        srv.logging.debug("Successfully sent Pushbullet notification")
+    except Exception:
+        srv.logging.exception("Sending Pushbullet notification failed")
         return False
 
     return True
+
+
+def send_note(access_token, title, body, recipient, recipient_type="device"):
+    """
+    Send a Pushbullet message with type=note.
+
+    https://docs.pushbullet.com/#push
+    """
+    headers = {
+        "Access-Token": access_token,
+        "Content-Type": "application/json",
+        "User-Agent": "mqttwarn",
+    }
+    data = {"type": "note", "title": title, "body": body}
+    if recipient_type is None:
+        pass
+    elif recipient_type == "device":
+        data["device_iden"] = recipient
+    elif recipient_type == "email":
+        data["email"] = recipient
+    elif recipient_type == "channel":
+        data["channel_tag"] = recipient
+    elif recipient_type == "client":
+        data["client_iden"] = recipient
+    else:
+        raise ValueError(f"Unknown recipient type: {recipient_type}")
+
+    response = requests.post("https://api.pushbullet.com/v2/pushes", headers=headers, json=data)
+    response.raise_for_status()
+
+    return response.status_code == requests.codes.ok

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,8 @@ extras = {
         "pyprowl>=3.0.1",
     ],
     "pushbullet": [
-        "PushbulletPythonLibrary>=2.3",
+        # TODO: Upstream `send_note` utility function.
+        # "pushbullet-python<2",
     ],
     "redispub": [
         "redis>=2.10.6",

--- a/tests/services/test_pushbullet.py
+++ b/tests/services/test_pushbullet.py
@@ -1,0 +1,329 @@
+# -*- coding: utf-8 -*-
+# (c) 2023 The mqttwarn developers
+import pytest
+import responses
+
+from mqttwarn.model import ProcessorItem as Item
+from mqttwarn.util import load_module_by_name
+
+# Canonical API response used for all tests.
+pushbullet_api_response = {
+    "active": True,
+    "body": "⚽ Notification message ⚽",
+    "created": 1412047948.579029,
+    "direction": "self",
+    "dismissed": False,
+    "iden": "ujpah72o0sjAoRtnM0jc",
+    "modified": 1412047948.579031,
+    "receiver_email": "test@example.org",
+    "receiver_email_normalized": "test@example.org",
+    "receiver_iden": "ujpah72o0",
+    "sender_email": "sender@example.org",
+    "sender_email_normalized": "sender@example.org",
+    "sender_iden": "ujpah72o0",
+    "sender_name": "Maxine Musterfrau",
+    "title": "⚽ Message title ⚽",
+    "type": "note",
+}
+
+
+@responses.activate
+def test_pushbullet_modern_email_success(srv, caplog):
+    """
+    Test the whole plugin with a successful outcome, using the modern configuration variant.
+
+    https://docs.pushbullet.com/#push
+    """
+
+    responses.add(
+        responses.POST,
+        "https://api.pushbullet.com/v2/pushes",
+        json=pushbullet_api_response,
+        status=200,
+    )
+
+    module = load_module_by_name("mqttwarn.services.pushbullet")
+
+    item = Item(
+        addrs={
+            "access_token": "a6FJVAA0LVJKrT8k",
+            "recipient": "test@example.org",
+            "recipient_type": "email",
+        },
+        title="⚽ Message title ⚽",
+        message="⚽ Notification message ⚽",
+        target="foo",
+    )
+
+    outcome = module.plugin(srv, item)
+
+    assert "Sending Pushbullet notification to foo" in caplog.messages
+    assert "Successfully sent Pushbullet notification" in caplog.messages
+    assert outcome is True
+
+    assert len(responses.calls) == 1
+    response = responses.calls[0]
+    assert response.request.url == "https://api.pushbullet.com/v2/pushes"
+    assert isinstance(response.request.body, bytes)
+    assert response.request.headers["User-Agent"] == "mqttwarn"
+    assert response.request.headers["Access-Token"] == "a6FJVAA0LVJKrT8k"
+
+    assert response.response.status_code == 200
+    assert response.response.json() == pushbullet_api_response
+
+
+@responses.activate
+def test_pushbullet_modern_device_success(srv, caplog):
+    """
+    Test the whole plugin with a successful outcome, using the modern configuration variant.
+
+    https://docs.pushbullet.com/#push
+    """
+
+    responses.add(
+        responses.POST,
+        "https://api.pushbullet.com/v2/pushes",
+        json=pushbullet_api_response,
+        status=200,
+    )
+
+    module = load_module_by_name("mqttwarn.services.pushbullet")
+
+    item = Item(
+        addrs={
+            "access_token": "a6FJVAA0LVJKrT8k",
+            "recipient": "ujpah72o0sjAoRtnM0jc",
+        },
+        title="⚽ Message title ⚽",
+        message="⚽ Notification message ⚽",
+        target="foo",
+    )
+
+    outcome = module.plugin(srv, item)
+
+    assert "Sending Pushbullet notification to foo" in caplog.messages
+    assert "Successfully sent Pushbullet notification" in caplog.messages
+    assert outcome is True
+
+
+@responses.activate
+@pytest.mark.parametrize("recipient_type", [None, "channel", "client"])
+def test_pushbullet_modern_recipient_types_success(srv, caplog, recipient_type):
+    """
+    Verify using all available recipient types works.
+    """
+
+    responses.add(
+        responses.POST,
+        "https://api.pushbullet.com/v2/pushes",
+        json={},
+        status=200,
+    )
+
+    module = load_module_by_name("mqttwarn.services.pushbullet")
+
+    item = Item(
+        addrs={
+            "access_token": "a6FJVAA0LVJKrT8k",
+            "recipient": "ujpah72o0sjAoRtnM0jc",
+            "recipient_type": recipient_type,
+        },
+        title="⚽ Message title ⚽",
+        message="⚽ Notification message ⚽",
+        target="foo",
+    )
+
+    outcome = module.plugin(srv, item)
+
+    assert "Sending Pushbullet notification to foo" in caplog.messages
+    assert "Successfully sent Pushbullet notification" in caplog.messages
+    assert outcome is True
+
+
+@responses.activate
+@pytest.mark.parametrize("recipient_type", ["unknown"])
+def test_pushbullet_modern_recipient_type_failure(srv, caplog, recipient_type):
+    """
+    Verify using an unknown recipient type fails.
+    """
+
+    responses.add(
+        responses.POST,
+        "https://api.pushbullet.com/v2/pushes",
+        json={},
+        status=200,
+    )
+
+    module = load_module_by_name("mqttwarn.services.pushbullet")
+
+    item = Item(
+        addrs={
+            "access_token": "a6FJVAA0LVJKrT8k",
+            "recipient": "ujpah72o0sjAoRtnM0jc",
+            "recipient_type": recipient_type,
+        },
+        title="⚽ Message title ⚽",
+        message="⚽ Notification message ⚽",
+        target="foo",
+    )
+
+    outcome = module.plugin(srv, item)
+
+    assert "Sending Pushbullet notification to foo" in caplog.messages
+    assert "Sending Pushbullet notification failed" in caplog.messages
+    assert outcome is False
+
+
+@responses.activate
+def test_pushbullet_legacy_device_success(srv, caplog):
+    """
+    Test the whole plugin with a successful outcome, using the legacy configuration variant.
+
+    https://docs.pushbullet.com/#push
+    """
+
+    responses.add(
+        responses.POST,
+        "https://api.pushbullet.com/v2/pushes",
+        json={},
+        status=200,
+    )
+
+    module = load_module_by_name("mqttwarn.services.pushbullet")
+
+    item = Item(
+        addrs=["a6FJVAA0LVJKrT8k", "ujpah72o0sjAoRtnM0jc"],
+        title="⚽ Message title ⚽",
+        message="⚽ Notification message ⚽",
+        target="foo",
+    )
+
+    outcome = module.plugin(srv, item)
+
+    assert "Sending Pushbullet notification to foo" in caplog.messages
+    assert "Successfully sent Pushbullet notification" in caplog.messages
+    assert outcome is True
+
+
+@responses.activate
+def test_pushbullet_legacy_email_success(srv, caplog):
+    """
+    Test the whole plugin with a successful outcome, using the legacy configuration variant.
+
+    https://docs.pushbullet.com/#push
+    """
+
+    responses.add(
+        responses.POST,
+        "https://api.pushbullet.com/v2/pushes",
+        json={},
+        status=200,
+    )
+
+    module = load_module_by_name("mqttwarn.services.pushbullet")
+
+    item = Item(
+        addrs=["a6FJVAA0LVJKrT8k", "test@example.org", "email"],
+        title="⚽ Message title ⚽",
+        message="⚽ Notification message ⚽",
+        target="foo",
+    )
+
+    outcome = module.plugin(srv, item)
+
+    assert "Sending Pushbullet notification to foo" in caplog.messages
+    assert "Successfully sent Pushbullet notification" in caplog.messages
+    assert outcome is True
+
+
+@responses.activate
+def test_pushbullet_legacy_failure(srv, caplog):
+    """
+    Test the whole plugin with a failure outcome, using the legacy configuration variant.
+
+    https://docs.pushbullet.com/#push
+    """
+
+    responses.add(
+        responses.POST,
+        "https://api.pushbullet.com/v2/pushes",
+        json={},
+        status=200,
+    )
+
+    module = load_module_by_name("mqttwarn.services.pushbullet")
+
+    item = Item(
+        addrs=["a6FJVAA0LVJKrT8k"],
+        title="⚽ Message title ⚽",
+        message="⚽ Notification message ⚽",
+        target="foo",
+    )
+
+    with pytest.raises(ValueError) as ex:
+        module.plugin(srv, item)
+    assert ex.match("Pushbullet target is incorrectly configured")
+
+
+@responses.activate
+def test_pushbullet_tad_wrong_type_failure(srv, caplog):
+    """
+    Test failure conditions of plugin.
+    """
+
+    responses.add(
+        responses.POST,
+        "https://api.pushbullet.com/v2/pushes",
+        json={},
+        status=200,
+    )
+
+    module = load_module_by_name("mqttwarn.services.pushbullet")
+
+    item = Item(
+        addrs=42.42,
+        title="⚽ Message title ⚽",
+        message="⚽ Notification message ⚽",
+        target="foo",
+    )
+
+    with pytest.raises(ValueError) as ex:
+        module.plugin(srv, item)
+    assert ex.match("Unknown target address descriptor type: float")
+
+
+@responses.activate
+def test_pushbullet_api_failure(srv, caplog, mocker):
+    """
+    Test failure conditions of plugin.
+    """
+
+    responses.add(
+        responses.POST,
+        "https://api.pushbullet.com/v2/pushes",
+        json={},
+        status=200,
+    )
+
+    module = load_module_by_name("mqttwarn.services.pushbullet")
+
+    item = Item(
+        addrs={
+            "access_token": "a6FJVAA0LVJKrT8k",
+            "recipient": "ujpah72o0sjAoRtnM0jc",
+        },
+        title="⚽ Message title ⚽",
+        message="⚽ Notification message ⚽",
+        target="foo",
+    )
+
+    def raise_exception(*args, **kwargs):
+        raise Exception("Something failed")
+
+    module.send_note = raise_exception
+
+    outcome = module.plugin(srv, item)
+    assert outcome is False
+
+    assert "Sending Pushbullet notification failed" in caplog.messages
+    assert "Something failed" in caplog.text


### PR DESCRIPTION
### About
Modernize [Pushbullet](https://pushbullet.com/) service plugin.

### Details
- Use Python 3
- Remove external dependencies
- Use named-parameter configuration style, with backwards-compatibility to the previous configuration style

### References
- GH-675

### Resources
- Documentation:
  https://mqttwarn--676.org.readthedocs.build/en/676/notifier-catalog.html#pushbullet
- Install using `pip`:
  ```
  pip install 'git+https://github.com/mqtt-tools/mqttwarn@amo/pushbullet'
  mqttwarn --version
  mqttwarn 0.34.1.post4+geabc781
  ```
- Use the OCI image:
  ```
  docker run --rm -it ghcr.io/mqtt-tools/mqttwarn-standard:pr-676 mqttwarn --version
  mqttwarn 0.34.1.post5+gf4a6a9e.d20230523
  ```
