### PR TITLE
CI: Fix OCI-full builds

### DIFF
--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -18,7 +18,7 @@ RUN \
     --mount=type=cache,id=apt,sharing=locked,target=/var/lib/apt \
     true \
     && apt-get update \
-    && apt-get install --no-install-recommends --no-install-suggests --yes git build-essential libmariadb-dev
+    && apt-get install --no-install-recommends --no-install-suggests --yes git build-essential libmariadb-dev pkg-config
 
 # Create /etc/mqttwarn
 RUN mkdir -p /etc/mqttwarn
@@ -37,7 +37,7 @@ RUN --mount=type=cache,id=pip,target=/root/.cache/pip \
     && pip install --use-pep517 --prefer-binary '/src[all]'
 
 # Uninstall build prerequisites again.
-RUN apt-get --yes remove --purge git build-essential libmariadb-dev && apt-get --yes autoremove
+RUN apt-get --yes remove --purge git build-essential libmariadb-dev pkg-config && apt-get --yes autoremove
 
 # Purge /src and /tmp directories.
 RUN rm -rf /src /tmp/*


### PR DESCRIPTION
After mysqlclient 2.2.0 [^1] has been released, the build needs the `pkg-config` package. Otherwise, the build fails [^2].

```
Exception: Can not find valid pkg-config name.
Specify MYSQLCLIENT_CFLAGS and MYSQLCLIENT_LDFLAGS env vars manually
```

[^1]: https://pypi.org/project/mysqlclient/
[^2]: https://github.com/mqtt-tools/mqttwarn/actions/runs/5352783113/jobs/9708043703#step:10:1715