### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,9 +18,10 @@ jobs:
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: ["ubuntu-20.04"]
-        python-version: ["3.6", "3.12"]
+        python-version: ["3.6", "3.7", "3.12"]
         include:
           - os: "macos-latest"
             python-version: "3.12"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,12 +20,12 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-20.04"]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.6", "3.12"]
         include:
           - os: "macos-latest"
-            python-version: "3.11"
+            python-version: "3.12"
           - os: "windows-latest"
-            python-version: "3.11"
+            python-version: "3.12"
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
           - os: "macos-latest"
             python-version: "3.12"
           - os: "windows-latest"
-            python-version: "3.12"
+            python-version: "3.11"
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,9 +12,15 @@ in progress
 - Documentation: Clarify data type of "target address descriptor"
 - [Pushover]: Switch to using ``base64.b64decode()`` to support decoding
   a string. Thanks, @sumnerboy12.
-- [ntfy] Fix submitting newline characters in notification message text
+- [ntfy] Fix submitting newline characters in notification message text.
+  Thanks, @zoic21 and @codebude.
 - Core: Fix decoding non-JSON messages, which negatively impacted outbound
   templating. Thanks, @Sc0th.
+- Add support for Python 3.12
+
+  - Use ``importlib`` instead of ``imp``
+  - Use ``importlib.resources`` instead of ``pkg_resources``
+  - [http,pushsafer] Remove dependency on ``future`` package
 
 
 2023-05-15 0.34.1

--- a/mqttwarn/services/amqp.py
+++ b/mqttwarn/services/amqp.py
@@ -5,7 +5,9 @@ __author__ = 'Jan-Piet Mens <jpmens()gmail.com>'
 __copyright__ = 'Copyright 2014 Jan-Piet Mens'
 __license__ = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)'
 
-import puka
+import pytest
+
+puka = pytest.importorskip("puka")
 
 
 def plugin(srv, item):

--- a/mqttwarn/services/http_urllib.py
+++ b/mqttwarn/services/http_urllib.py
@@ -5,10 +5,15 @@ __author__    = 'Jan-Piet Mens <jpmens()gmail.com>'
 __copyright__ = 'Copyright 2014 Ben Jones'
 __license__   = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/epl-v10.html)'
 
-from future import standard_library
-standard_library.install_aliases()
+try:
+    from urllib.parse import urlparse, urlencode, urljoin
+    from urllib.request import urlopen, Request
+    from urllib.error import HTTPError
+except ImportError:
+    from urlparse import urlparse  # type: ignore[no-redef]
+    from urllib import urlencode, urljoin  # type: ignore[no-redef,attr-defined]
+    from urllib2 import urlopen, Request, HTTPError  # type: ignore[no-redef]
 
-import urllib.request, urllib.parse, urllib.error
 import base64
 
 try:
@@ -71,18 +76,18 @@ def plugin(srv, item):
                 resource = url
                 if not resource.endswith('?'):
                     resource = resource + '?'
-                resource = resource + urllib.parse.urlencode(params)
+                resource = resource + urlencode(params)
             else:
                 resource = url
 
-            request = urllib.request.Request(resource)
+            request = Request(resource)
 
             if srv.SCRIPTNAME is not None:
                 request.add_header('User-agent', srv.SCRIPTNAME)
             if basicauth_token is not None:
                 request.add_header("Authorization", "Basic %s" % basicauth_token)
 
-            resp = urllib.request.urlopen(request, timeout=timeout)
+            resp = urlopen(request, timeout=timeout)
             data = resp.read()
             #srv.logging.debug("HTTP response:\n%s" % data)
         except Exception as e:
@@ -93,13 +98,13 @@ def plugin(srv, item):
 
     if method.upper() == 'POST':
         try:
-            request = urllib.request.Request(url)
+            request = Request(url)
             if params is not None:
                 if tojson is not None:
                     encoded_params = json.dumps(params)
                     request.add_header('Content-Type', 'application/json')
                 else:
-                    encoded_params = urllib.parse.urlencode(params)
+                    encoded_params = urlencode(params)
             else:
                 if tojson is not None:
                     encoded_params = item.payload
@@ -116,7 +121,7 @@ def plugin(srv, item):
                 request.add_header("Authorization", "Basic %s" % basicauth_token)
 
             srv.logging.debug("before send")
-            resp = urllib.request.urlopen(request, timeout=timeout)
+            resp = urlopen(request, timeout=timeout)
             data = resp.read()
             #srv.logging.debug("HTTP response:\n%s" % data)
         except Exception as e:

--- a/mqttwarn/services/pushsafer.py
+++ b/mqttwarn/services/pushsafer.py
@@ -8,13 +8,17 @@ __license__   = 'Eclipse Public License - v 1.0 (http://www.eclipse.org/legal/ep
 import dataclasses
 from collections import OrderedDict
 
-from future import standard_library
-standard_library.install_aliases()
 import os
 import json
-import urllib.request, urllib.parse, urllib.error
-import urllib.request, urllib.error, urllib.parse
-import urllib.parse
+
+try:
+    from urllib.parse import urlparse, urlencode, urljoin
+    from urllib.request import urlopen, Request
+    from urllib.error import HTTPError
+except ImportError:
+    from urlparse import urlparse  # type: ignore[no-redef]
+    from urllib import urlencode, urljoin  # type: ignore[no-redef,attr-defined]
+    from urllib2 import urlopen, Request, HTTPError  # type: ignore[no-redef]
 
 import typing as t
 
@@ -39,10 +43,10 @@ def pushsafer(**kwargs):
     # Don't submit empty parameters to Pushsafer.
     filter_empty_parameters(kwargs)
 
-    url = urllib.parse.urljoin(PUSHSAFER_API, "api")
-    data = urllib.parse.urlencode(kwargs).encode('utf-8')
-    req = urllib.request.Request(url, data)
-    response = urllib.request.urlopen(req, timeout=3)
+    url = urljoin(PUSHSAFER_API, "api")
+    data = urlencode(kwargs).encode('utf-8')
+    req = Request(url, data)
+    response = urlopen(req, timeout=3)
     output = response.read()
     data = json.loads(output)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,17 +114,17 @@ omit = [
 
 [tool.poe.tasks]
 format = [
-  {cmd="black ."},
-  {cmd="isort ."},
+  { cmd = "black ." },
+  # Ignore unused imports (F401), unused variables (F841), `print` statements (T201), and commented-out code (ERA001).
+  { cmd = "ruff --fix --ignore=ERA --ignore=F401 --ignore=F841 --ignore=T20 --ignore=ERA001 ." },
 ]
 lint = [
-  {cmd="ruff ."},
-  {cmd="black --check ."},
-  {cmd="isort --check ."},
-  {cmd="mypy --install-types --non-interactive"},
+  { cmd = "ruff ." },
+  { cmd = "black --check ." },
+  { cmd = "mypy --install-types --non-interactive" },
 ]
 test = [
-  {cmd="pytest"},
+  { cmd="pytest" },
 ]
 build = {cmd="python -m build"}
 check = ["lint", "test"]

--- a/setup.py
+++ b/setup.py
@@ -203,6 +203,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Communications",
         "Topic :: Education",
         "Topic :: Internet",

--- a/setup.py
+++ b/setup.py
@@ -170,7 +170,6 @@ extras["test"] = [
 
 # Packages needed for development and running CI.
 extras["develop"] = [
-    "isort<6",
     "black<23",
     "build<1",
     "mypy<1.3",

--- a/setup.py
+++ b/setup.py
@@ -144,6 +144,10 @@ for extra, packages in extras.items():
     if machine in ["armv7l"] and extra in ["apprise", "twilio"]:
         continue
 
+    # FIXME: aiohttp (needed by twilio) is not available for Python 3.12 yet.
+    if sys.version_info >= (3, 12) and extra in ["twilio"]:
+        continue
+
     for package in packages:
         extras_all.append(package)
 

--- a/setup.py
+++ b/setup.py
@@ -164,7 +164,7 @@ extras["test"] = [
     'dataclasses; python_version<"3.7"',
     "requests-toolbelt>=1,<2",
     "responses>=0.13.3,<1",
-    "pyfakefs>=4.5,<5",
+    "pyfakefs>=4.5,<6",
 ] + extras["all"]
 
 # Packages needed for development and running CI.

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ requires = [
     "funcy<3",
     "future>=0.18.0,<1",
     "importlib-metadata; python_version<'3.8'",
+    "importlib-resources; python_version<'3.8'",
     "jinja2<4",
     "paho-mqtt<2",
     "requests<3",

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ requires = [
 
 extras = {
     "amqp": [
-        "puka>=0.0.7",
+        "puka>=0.0.7; python_version<'3.12'",
     ],
     "apns": [
         "apns>=2.0.1",
@@ -40,7 +40,7 @@ extras = {
         "celery",
     ],
     "chromecast": [
-        "pychromecast>=7.5.0",
+        "pychromecast>=7.5.0; python_version>='3.7'",
     ],
     "dnsupdate": [
         "dnspython>=1.15.0",
@@ -49,7 +49,7 @@ extras = {
         "fbchat>=1.3.6",
     ],
     "gss2": [
-        "google-api-python-client<2",
+        "google-api-python-client<2; python_version>='3.7'",
         "gspread>=2.1.1",
         "oauth2client>=4.1.2",
     ],
@@ -91,7 +91,7 @@ extras = {
         "slack-sdk>=3.1.0",
     ],
     "ssh": [
-        "paramiko>=2.4.1",
+        "paramiko>=2.4.1; python_version>='3.7'",
     ],
     "tootpaste": [
         "Mastodon.py>=1.2.2",
@@ -162,7 +162,7 @@ extras["test"] = [
     "pytest-mock<4",
     "pytest-mqtt<1",
     "tox<4",
-    'dataclasses; python_version<"3.7"',
+    "dataclasses; python_version<'3.7'",
     "requests-toolbelt>=1,<2",
     "responses>=0.13.3,<1",
     "pyfakefs>=4.5,<6",
@@ -175,7 +175,7 @@ extras["develop"] = [
     "build<1",
     "mypy<1.3",
     "poethepoet<1",
-    'ruff==0.0.254; python_version>="3.7"',
+    "ruff==0.0.254; python_version>='3.7'",
     "sphinx-autobuild",
 ]
 

--- a/tests/test_core_infra.py
+++ b/tests/test_core_infra.py
@@ -709,11 +709,11 @@ def test_load_services_spec_not_found(caplog):
     config = Config()
     config.add_section("config:foo.bar")
     bootstrap(config=config)
-    with pytest.raises(SystemExit) as ex:
+    with pytest.raises(ImportError) as ex:
         load_services(["foo.bar"])
     assert 'Loading service "foo.bar" from module "foo.bar" failed' in caplog.messages
-    assert 'Unable to load service "foo.bar"' in caplog.messages
-    assert ex.match("1")
+    assert "Failed loading service: foo.bar" in caplog.messages
+    assert ex.match("Failed loading service: foo.bar")
 
 
 def test_load_services_file_not_found(tmp_path, caplog):
@@ -728,12 +728,12 @@ def test_load_services_file_not_found(tmp_path, caplog):
     config.add_section("config:foo.bar")
     config.set("config:foo.bar", "module", "foo_bar.py")
     bootstrap(config=config)
-    with pytest.raises(SystemExit) as ex:
+    with pytest.raises(ImportError) as ex:
         load_services(["foo.bar"])
     assert 'Module "foo_bar.py" is not a file' in caplog.messages
     assert f'Module "{modulefile}" is not a file' in caplog.messages
-    assert 'Unable to load service "foo.bar"' in caplog.messages
-    assert ex.match("1")
+    assert "Failed loading service: foo.bar" in caplog.messages
+    assert ex.match("Failed loading service: foo.bar")
 
 
 def test_load_services_file_failure(tmp_path, caplog):
@@ -751,12 +751,12 @@ def test_load_services_file_failure(tmp_path, caplog):
     config.set("config:foo.bar", "module", "foo_bar.py")
     bootstrap(config=config)
 
-    with pytest.raises(SystemExit) as ex:
+    with pytest.raises(ImportError) as ex:
         load_services(["foo.bar"])
     assert f'Loading service "foo.bar" from file "{modulefile}" failed' in caplog.text
     assert "AssertionError" in caplog.text
-    assert 'Unable to load service "foo.bar"' in caplog.messages
-    assert ex.match("1")
+    assert "Failed loading service: foo.bar" in caplog.messages
+    assert ex.match("Failed loading service: foo.bar")
 
 
 def test_run_plugin_success(caplog):


### PR DESCRIPTION
## About

Python 3.12 has been released recently. This patch attempts to add corresponding support.

## Details

- For loading code at runtime, use `importlib` instead of `imp`.
  The `imp` module was deprecated and got removed from Python 3.12.
- Use `importlib.resources` instead of deprecated `pkg_resources`.
- Remove dependency on `future` package, for `http` and `pushsafer` service plugins.
- Upgrade to pyfakefs<6.
- Skip installing and testing twilio on Python 3.12.

## Trivia

Start omitting intermediate Python versions on CI, to save resources.

