### PR TITLE
Patch for a shorthand definition of quoted fields in http_urllib

### DIFF
--- a/mqttwarn/services/http_urllib.py
+++ b/mqttwarn/services/http_urllib.py
@@ -24,8 +24,8 @@ except ImportError:
 
 def plugin(srv, item):
     """ addrs: (method, url, dict(params), list(username, password), json) 
-        or (shorthand)
-        addrs: (method, url, list(params), list(username, password), json)  """
+        or (shorthand for quoted fields)
+        addrs: (method, url, list(param_names), list(username, password), json)  """
 
     srv.logging.debug("*** MODULE=%s: service=%s, target=%s", __file__, item.service, item.target)
 
@@ -73,7 +73,8 @@ def plugin(srv, item):
             # Quoted field, starts with '@'. Do not use .format, instead grab
             # the item's [message] and inject as parameter value.
             # { 'x' : '?param' }
-            # optional quoted field, add to query string only if it exists in item's data and is not empty 
+            # Optional quoted field, add to query string only if it exists
+            # in item's data and is not empty 
             if params[key].startswith('@'):         # "@message"
                 params[key] = item.get(params[key][1:], "NOP")
 

--- a/mqttwarn/services/http_urllib.py
+++ b/mqttwarn/services/http_urllib.py
@@ -56,7 +56,7 @@ def plugin(srv, item):
 
     if params is not None:
         
-        # shorthand [ 'param1' ] for { 'param1': '{param1}, ...}
+        # shorthand [ 'param1' ] for { 'param1': '{param1}', ...}
         if isinstance(params, list):
             # create dict from list and replace params
             newparams = {}
@@ -64,7 +64,7 @@ def plugin(srv, item):
                 if key.startswith('@') or key.startswith('?'):
                     newparams[key[1:]] = key
                 else:
-                    newparams[key] = key
+                    newparams[key] = '@' + key
             params = newparams
             
         for key in list(params.keys()):
@@ -73,7 +73,7 @@ def plugin(srv, item):
             # Quoted field, starts with '@'. Do not use .format, instead grab
             # the item's [message] and inject as parameter value.
             # { 'x' : '?param' }
-            # optional field, add to query string only if it exists in data and is not empty 
+            # optional quoted field, add to query string only if it exists in item's data and is not empty 
             if params[key].startswith('@'):         # "@message"
                 params[key] = item.get(params[key][1:], "NOP")
 

--- a/mqttwarn/services/http_urllib.py
+++ b/mqttwarn/services/http_urllib.py
@@ -56,7 +56,8 @@ def plugin(srv, item):
 
     if params is not None:
         
-        # shorthand [ 'param1' ] for { 'param1': '{param1}', ...}
+        # shorthand [ 'param1' , '@param2', '?param3' ] 
+        # for { 'param1': '@param1', 'param2': '@param2', 'param3': '?param3' }
         if isinstance(params, list):
             # create dict from list and replace params
             newparams = {}
@@ -72,14 +73,14 @@ def plugin(srv, item):
             # { 'q' : '@message' }
             # Quoted field, starts with '@'. Do not use .format, instead grab
             # the item's [message] and inject as parameter value.
-            # { 'x' : '?param' }
+            # new { 'x' : '?param' }
             # Optional quoted field, add to query string only if it exists
             # in item's data and is not empty 
             if params[key].startswith('@'):         # "@message"
-                params[key] = item.get(params[key][1:], "NOP")
+                params[key] = item.data.get(params[key][1:], "NOP")
 
             elif params[key].startswith('?'):
-                myitem = item.get(params[key][1:], None)
+                myitem = item.data.get(params[key][1:], None)
                 if myitem is None:
                     params.pop(key,None)
                 else:

--- a/mqttwarn/services/http_urllib.py
+++ b/mqttwarn/services/http_urllib.py
@@ -23,7 +23,9 @@ except ImportError:
 
 
 def plugin(srv, item):
-    """ addrs: (method, url, dict(params), list(username, password), json) """
+    """ addrs: (method, url, dict(params), list(username, password), json) 
+        or (shorthand)
+        addrs: (method, url, list(params), list(username, password), json)  """
 
     srv.logging.debug("*** MODULE=%s: service=%s, target=%s", __file__, item.service, item.target)
 
@@ -53,13 +55,34 @@ def plugin(srv, item):
         pass
 
     if params is not None:
+        
+        # shorthand [ 'param1' ] for { 'param1': '{param1}, ...}
+        if isinstance(params, list):
+            # create dict from list and replace params
+            newparams = {}
+            for key in params:
+                if key.startswith('@') or key.startswith('?'):
+                    newparams[key[1:]] = key
+                else:
+                    newparams[key] = key
+            params = newparams
+            
         for key in list(params.keys()):
 
             # { 'q' : '@message' }
             # Quoted field, starts with '@'. Do not use .format, instead grab
             # the item's [message] and inject as parameter value.
+            # { 'x' : '?param' }
+            # optional field, add to query string only if it exists in data and is not empty 
             if params[key].startswith('@'):         # "@message"
                 params[key] = item.get(params[key][1:], "NOP")
+
+            elif params[key].startswith('?'):
+                myitem = item.get(params[key][1:], None)
+                if myitem is None:
+                    params.pop(key,None)
+                else:
+                    params[key] = myitem
 
             else:
                 try:


### PR DESCRIPTION
When working with a greater number of transformed fields (e. g. through topic's alldata), the params definition for the target has a lot of redundancy, especially when the field names are crafted to be the parameter names of the query parameters:

This patch provides a shorthand for a definition like 
`[ #method, #url, { 'param1' : '@param1', ..., 'paramN': '@paramN' }, ...`
by allowing lists for the 3rd parameter of the target definition:
`[ #method, #url, [ '?param1', ..., '?paramN' ], ...`

If a list is provided

- the given names will be used as both keys do item.data{} and query parameter names
- they will be added as quoted fields, regardless of whether the @-prefix is provided: `[ 'param1', ..., 'paramN' ]` will be interpreted as `[ '@param1', ..., '@paramN' ]`
- with the prefix `?`, fields can be declared optional: they will not be included in the query if the data is invalid or missing from item.data{}; `[ 'param1', '?param2', ... ]`